### PR TITLE
best_practices: encourage use of pylint, six, and python-modernize

### DIFF
--- a/deliverables/transition_guide.md
+++ b/deliverables/transition_guide.md
@@ -1,4 +1,4 @@
-# Best Practices
+# Python 3 Transition Guide
 
 This document collates some best practices and advice to consider
 when transitioning to Python 3.


### PR DESCRIPTION
Add a section describing the Conservative Python 3 Porting Guide,
the python-futures Python 3 Compatibility Cheat Sheet, and the
python-modernize tool.

Recommend use of pylint --py3k.
Recommend use of six and python-modernize.
Add guidance for futurize and the python-future modules.

Signed-off-by: David Aguilar <davvid@gmail.com>